### PR TITLE
Add license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "schickling/queue-checker",
     "description": "Command to check the queue health status",
+    "licene": "MIT",
     "authors": [
         {
             "name": "Johannes Schickling",


### PR DESCRIPTION
Can be put to something else but otherwise a package without any license is a proprietary one.
